### PR TITLE
Cleanup duplicate helpers

### DIFF
--- a/standalone/msg_diagnostic.py
+++ b/standalone/msg_diagnostic.py
@@ -8,7 +8,6 @@ import sys
 import os
 import json
 import pprint
-from typing import Any, Dict, List
 
 try:
     import extract_msg


### PR DESCRIPTION
## Summary
- drop unused imports
- remove duplicate helper functions
- fix bare `except:` clauses to catch specific errors
- restore a single `_normalize_msg_content` implementation

## Testing
- `flake8 | head`
- `python3 -m py_compile standalone/parse.py standalone/msg_diagnostic.py && echo "compile success"`


------
https://chatgpt.com/codex/tasks/task_e_686ab81193348324b3952e3ed632b159