### PR TITLE
Refactor monolithic parser into package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# email-parser
+# Email Parser
+
+This project provides a small library for parsing `.eml` and `.msg` files with a simple command line interface.
+
+## Usage
+
+```bash
+python -m email_parser.cli path/to/email.eml
+```

--- a/diagnostics/msg_diagnostic.py
+++ b/diagnostics/msg_diagnostic.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+MSG File Diagnostic Script
+Comprehensive analysis of what extract_msg can extract from a MSG file
+"""
+
+import sys
+import os
+import json
+import pprint
+
+try:
+    import extract_msg
+    MSG_SUPPORT = True
+except ImportError:
+    MSG_SUPPORT = False
+    print("ERROR: extract_msg not available. Install with: pip install extract-msg")
+    sys.exit(1)
+
+def safe_repr(obj, max_length=200):
+    """Safely represent an object for printing, truncating if too long."""
+    try:
+        if obj is None:
+            return "None"
+        elif isinstance(obj, bytes):
+            if len(obj) > max_length:
+                return f"<bytes: length={len(obj)}, preview={obj[:50]!r}...>"
+            return repr(obj)
+        elif isinstance(obj, str):
+            if len(obj) > max_length:
+                return f"<string: length={len(obj)}, preview={obj[:50]!r}...>"
+            return repr(obj)
+        else:
+            str_repr = str(obj)
+            if len(str_repr) > max_length:
+                return f"<{type(obj).__name__}: {str_repr[:max_length]}...>"
+            return str_repr
+    except Exception as e:
+        return f"<Error representing object: {e}>"
+
+def analyze_msg_object(msg, prefix="", max_depth=3, current_depth=0):
+    """Recursively analyze all properties and methods of the MSG object."""
+    if current_depth > max_depth:
+        return {"_truncated": "Max depth reached"}
+    
+    analysis = {}
+    
+    # Get all attributes
+    for attr_name in sorted(dir(msg)):
+        if attr_name.startswith('_'):
+            continue
+            
+        try:
+            attr_value = getattr(msg, attr_name)
+            
+            # Skip methods and functions for now
+            if callable(attr_value):
+                if not attr_name.startswith('get') and attr_name not in ['save', 'close']:
+                    continue
+                else:
+                    # For getter methods, try to call them
+                    try:
+                        if attr_name.startswith('get') and '(' in str(attr_value):
+                            continue  # Skip methods that require parameters
+                        result = attr_value() if callable(attr_value) else attr_value
+                        analysis[f"{attr_name}()"] = safe_repr(result)
+                    except Exception as e:
+                        analysis[f"{attr_name}()"] = f"<Error calling method: {e}>"
+                continue
+            
+            # For non-callable attributes
+            if hasattr(attr_value, '__dict__') and current_depth < max_depth:
+                # Recursively analyze objects
+                analysis[attr_name] = analyze_msg_object(attr_value, f"{prefix}{attr_name}.", max_depth, current_depth + 1)
+            else:
+                analysis[attr_name] = safe_repr(attr_value)
+                
+        except Exception as e:
+            analysis[attr_name] = f"<Error accessing attribute: {e}>"
+    
+    return analysis
+
+def analyze_attachments(msg):
+    """Analyze attachments in detail."""
+    attachment_analysis = []
+    
+    try:
+        if hasattr(msg, 'attachments') and msg.attachments:
+            for i, attachment in enumerate(msg.attachments):
+                att_info = {
+                    "index": i,
+                    "properties": analyze_msg_object(attachment, f"attachment_{i}.", max_depth=2)
+                }
+                
+                # Try to get specific attachment properties
+                for prop in ['longFilename', 'shortFilename', 'data', 'size']:
+                    try:
+                        value = getattr(attachment, prop, None)
+                        if prop == 'data' and value:
+                            att_info[prop] = f"<bytes: length={len(value)}, type_detected='{detect_content_type(value)}'>"
+                        else:
+                            att_info[prop] = safe_repr(value)
+                    except Exception as e:
+                        att_info[prop] = f"<Error: {e}>"
+                
+                attachment_analysis.append(att_info)
+    except Exception as e:
+        return {"error": f"Error analyzing attachments: {e}"}
+    
+    return attachment_analysis
+
+def detect_content_type(data):
+    """Simple content type detection based on magic bytes."""
+    if not data or len(data) < 4:
+        return "unknown"
+    
+    # Check for common file signatures
+    signatures = {
+        b'\x89PNG': 'PNG image',
+        b'\xff\xd8\xff': 'JPEG image', 
+        b'GIF8': 'GIF image',
+        b'%PDF': 'PDF document',
+        b'\xd0\xcf\x11\xe0': 'OLE/MSG document',
+        b'PK\x03\x04': 'ZIP/Office document',
+        b'From:': 'Email content',
+        b'Received:': 'Email content',
+        b'Return-Path:': 'Email content',
+    }
+    
+    for signature, description in signatures.items():
+        if data.startswith(signature):
+            return description
+    
+    return "unknown"
+
+def analyze_content_encoding(content):
+    """Analyze the encoding of content."""
+    if content is None:
+        return {"status": "None"}
+    
+    analysis = {
+        "type": type(content).__name__,
+        "length": len(content) if hasattr(content, '__len__') else "unknown"
+    }
+    
+    if isinstance(content, bytes):
+        # Check for UTF-16 patterns
+        if len(content) >= 4:
+            if content[:2] == b'\xff\xfe' or content[:2] == b'\xfe\xff':
+                analysis["utf16_bom"] = "detected"
+            
+            # Check for alternating null bytes (UTF-16LE ASCII pattern)
+            null_count = sum(1 for i in range(1, min(20, len(content)), 2) if content[i] == 0)
+            analysis["null_byte_pattern"] = f"{null_count}/10 in even positions"
+        
+        # Try different decodings
+        encodings_tried = {}
+        for encoding in ['utf-8', 'utf-16le', 'utf-16', 'windows-1252', 'latin-1']:
+            try:
+                decoded = content.decode(encoding)
+                preview = decoded[:100].replace('\n', '\\n').replace('\r', '\\r')
+                encodings_tried[encoding] = f"success: {preview!r}"
+            except Exception as e:
+                encodings_tried[encoding] = f"failed: {e}"
+        
+        analysis["encoding_attempts"] = encodings_tried
+    
+    elif isinstance(content, str):
+        analysis["preview"] = content[:200].replace('\n', '\\n').replace('\r', '\\r')
+        
+        # Check for Unicode escape sequences
+        if '\\u' in content[:100]:
+            analysis["unicode_escapes"] = "detected"
+    
+    return analysis
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python msg_diagnostic.py <msg_file>")
+        sys.exit(1)
+    
+    msg_file = sys.argv[1]
+    
+    if not os.path.exists(msg_file):
+        print(f"Error: File {msg_file} not found")
+        sys.exit(1)
+    
+    print(f"Analyzing MSG file: {msg_file}")
+    print("=" * 80)
+    
+    try:
+        # Open the MSG file
+        msg = extract_msg.Message(msg_file)
+        
+        print("\n1. BASIC MSG PROPERTIES")
+        print("-" * 40)
+        
+        # Basic properties
+        basic_props = ['sender', 'to', 'cc', 'subject', 'date', 'messageId']
+        for prop in basic_props:
+            try:
+                value = getattr(msg, prop, None)
+                print(f"{prop}: {safe_repr(value)}")
+            except Exception as e:
+                print(f"{prop}: <Error: {e}>")
+        
+        print("\n2. BODY CONTENT ANALYSIS")
+        print("-" * 40)
+        
+        # Analyze body content
+        print("Plain body analysis:")
+        plain_analysis = analyze_content_encoding(getattr(msg, 'body', None))
+        pprint.pprint(plain_analysis, width=120)
+        
+        print("\nHTML body analysis:")
+        html_analysis = analyze_content_encoding(getattr(msg, 'htmlBody', None))
+        pprint.pprint(html_analysis, width=120)
+        
+        print("\n3. ALL MSG OBJECT PROPERTIES")
+        print("-" * 40)
+        
+        # Full property analysis
+        full_analysis = analyze_msg_object(msg, max_depth=2)
+        
+        # Group properties by category
+        content_props = {}
+        meta_props = {}
+        other_props = {}
+        
+        for key, value in full_analysis.items():
+            if any(term in key.lower() for term in ['body', 'text', 'html', 'content', 'message']):
+                content_props[key] = value
+            elif any(term in key.lower() for term in ['date', 'time', 'id', 'header', 'sender', 'recipient']):
+                meta_props[key] = value
+            else:
+                other_props[key] = value
+        
+        print("\nContent-related properties:")
+        pprint.pprint(content_props, width=120)
+        
+        print("\nMetadata properties:")
+        pprint.pprint(meta_props, width=120)
+        
+        print("\nOther properties:")
+        pprint.pprint(other_props, width=120)
+        
+        print("\n4. ATTACHMENT ANALYSIS")
+        print("-" * 40)
+        
+        attachment_analysis = analyze_attachments(msg)
+        pprint.pprint(attachment_analysis, width=120)
+        
+        print("\n5. RAW PROPERTIES DUMP")
+        print("-" * 40)
+        
+        # Check if there are any properties that might contain raw email data
+        print("Looking for properties that might contain raw email data:")
+        
+        for attr_name in sorted(dir(msg)):
+            if any(term in attr_name.lower() for term in ['raw', 'stream', 'data', 'property', 'original']):
+                try:
+                    value = getattr(msg, attr_name)
+                    if not callable(value):
+                        print(f"{attr_name}: {safe_repr(value, 100)}")
+                except Exception as e:
+                    print(f"{attr_name}: <Error: {e}>")
+        
+        # Check for internal properties that might be useful
+        print("\nInternal/private properties (might contain useful data):")
+        for attr_name in sorted(dir(msg)):
+            if attr_name.startswith('_') and not attr_name.startswith('__'):
+                try:
+                    value = getattr(msg, attr_name)
+                    if not callable(value):
+                        print(f"{attr_name}: {safe_repr(value, 100)}")
+                except Exception as e:
+                    print(f"{attr_name}: <Error: {e}>")
+        
+        # Save full analysis to JSON file
+        output_file = f"{msg_file}_diagnostic.json"
+        try:
+            with open(output_file, 'w', encoding='utf-8') as f:
+                diagnostic_data = {
+                    "basic_properties": {prop: safe_repr(getattr(msg, prop, None)) for prop in basic_props},
+                    "body_analysis": {
+                        "plain_body": plain_analysis,
+                        "html_body": html_analysis
+                    },
+                    "all_properties": full_analysis,
+                    "attachments": attachment_analysis
+                }
+                json.dump(diagnostic_data, f, indent=2, ensure_ascii=False, default=str)
+            print(f"\nFull diagnostic data saved to: {output_file}")
+        except Exception as e:
+            print(f"\nWarning: Could not save diagnostic data to JSON: {e}")
+        
+        # Close the MSG object
+        if hasattr(msg, 'close'):
+            msg.close()
+        elif hasattr(msg, '__exit__'):
+            msg.__exit__(None, None, None)
+            
+    except Exception as e:
+        print(f"Error analyzing MSG file: {e}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    main()

--- a/email_parser/__init__.py
+++ b/email_parser/__init__.py
@@ -1,0 +1,3 @@
+from .parser import EmailParser
+
+__all__ = ["EmailParser"]

--- a/email_parser/cli.py
+++ b/email_parser/cli.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .parser import EmailParser
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Email parsing utility")
+    parser.add_argument("file", type=Path, help="Input email file (.eml or .msg)")
+    args = parser.parse_args()
+
+    ep = EmailParser()
+    data = args.file.read_bytes()
+    result = ep.parse(data, args.file.name)
+    print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/email_parser/content_analyzer.py
+++ b/email_parser/content_analyzer.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import struct
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+
+@dataclass
+class FileAnalysis:
+    filename: Optional[str]
+    declared_mime_type: Optional[str]
+    size: int
+    detected_type: str
+    confidence: float
+    mime_type: str
+    file_extension: Optional[str]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    hashes: Dict[str, str] = field(default_factory=dict)
+    encoding_info: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+
+class ContentAnalyzer:
+    """Basic content analysis for file type detection and metadata extraction."""
+
+    MAGIC_SIGNATURES: Dict[str, list[tuple]] = {
+        "png": [(b"\x89PNG\r\n\x1a\n", 0)],
+        "jpeg": [(b"\xff\xd8\xff", 0)],
+        "gif": [(b"GIF87a", 0), (b"GIF89a", 0)],
+        "bmp": [(b"BM", 0)],
+        "tiff": [(b"II*\x00", 0), (b"MM\x00*", 0)],
+        "ico": [(b"\x00\x00\x01\x00", 0)],
+        "webp": [(b"RIFF", 0, b"WEBP", 8)],
+        "pdf": [(b"%PDF-", 0)],
+        "msg": [(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", 0)],
+        "eml": [(b"Return-Path:", 0), (b"From:", 0)],
+    }
+
+    def __init__(self, logger: logging.Logger) -> None:
+        self.logger = logger
+
+    def analyze_content(
+        self, data: bytes, filename: str | None = None, declared_mime: str | None = None
+    ) -> FileAnalysis:
+        if not data:
+            return FileAnalysis(
+                filename=filename,
+                declared_mime_type=declared_mime,
+                size=0,
+                detected_type="unknown",
+                confidence=0.0,
+                mime_type="application/octet-stream",
+                file_extension=None,
+                error="No data provided",
+            )
+
+        detected_type, confidence = self._detect_by_magic_bytes(data)
+        analysis = FileAnalysis(
+            filename=filename,
+            declared_mime_type=declared_mime,
+            size=len(data),
+            detected_type=detected_type,
+            confidence=confidence,
+            mime_type=self._get_mime_type(detected_type),
+            file_extension=os.path.splitext(filename)[1].lstrip(".") if filename else None,
+        )
+        analysis.hashes = self._generate_hashes(data)
+        analysis.metadata = self._extract_metadata(data, detected_type)
+        analysis.encoding_info = self._analyze_encoding(data)
+        return analysis
+
+    def _detect_by_magic_bytes(self, data: bytes) -> Tuple[str, float]:
+        if len(data) < 16:
+            return "unknown", 0.0
+        for ftype, sigs in self.MAGIC_SIGNATURES.items():
+            for sig in sigs:
+                if len(sig) == 2:
+                    signature, offset = sig
+                    if data[offset : offset + len(signature)] == signature:
+                        return ftype, 0.9
+                elif len(sig) == 4:
+                    sig1, off1, sig2, off2 = sig
+                    if (
+                        data[off1 : off1 + len(sig1)] == sig1
+                        and data[off2 : off2 + len(sig2)] == sig2
+                    ):
+                        return ftype, 0.95
+        return "unknown", 0.0
+
+    def _get_mime_type(self, detected_type: str) -> str:
+        mime_map = {
+            "png": "image/png",
+            "jpeg": "image/jpeg",
+            "gif": "image/gif",
+            "bmp": "image/bmp",
+            "tiff": "image/tiff",
+            "webp": "image/webp",
+            "pdf": "application/pdf",
+            "msg": "application/vnd.ms-outlook",
+            "eml": "message/rfc822",
+        }
+        return mime_map.get(detected_type, "application/octet-stream")
+
+    def _generate_hashes(self, data: bytes) -> Dict[str, str]:
+        return {
+            "md5": hashlib.md5(data).hexdigest(),
+            "sha1": hashlib.sha1(data).hexdigest(),
+            "sha256": hashlib.sha256(data).hexdigest(),
+        }
+
+    def _extract_metadata(self, data: bytes, file_type: str) -> Dict[str, Any]:
+        metadata: Dict[str, Any] = {}
+        if file_type == "pdf" and data.startswith(b"%PDF-"):
+            match = re.search(rb"%PDF-(\d+\.\d+)", data[:10])
+            if match:
+                metadata["pdf_version"] = match.group(1).decode()
+        return metadata
+
+    def _analyze_encoding(self, data: bytes) -> Dict[str, Any]:
+        info: Dict[str, Any] = {}
+        ascii_ratio = sum(1 for b in data[:1024] if 32 <= b <= 126) / min(len(data), 1024)
+        info["ascii_ratio"] = round(ascii_ratio, 3)
+        info["entropy"] = round(self._calculate_entropy(data[:4096]), 3)
+        return info
+
+    def _calculate_entropy(self, data: bytes) -> float:
+        if not data:
+            return 0.0
+        freq = [0] * 256
+        for b in data:
+            freq[b] += 1
+        length = len(data)
+        entropy = 0.0
+        for count in freq:
+            if count:
+                p = count / length
+                entropy -= p * (p.bit_length() - 1)  # approximate log2
+        return entropy

--- a/email_parser/format_detector.py
+++ b/email_parser/format_detector.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional, Tuple
+
+
+class EmailFormatDetector:
+    """Detect email format using simple heuristics and magic bytes."""
+
+    MAGIC_SIGNATURES = {
+        "msg": [b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"],
+        "eml": [b"Return-Path:", b"From:"] ,
+    }
+
+    def __init__(self, logger: logging.Logger) -> None:
+        self.logger = logger
+
+    def detect_by_magic_bytes(self, data: bytes) -> Optional[str]:
+        if len(data) < 4:
+            return None
+        header = data[:512]
+        for fmt, sigs in self.MAGIC_SIGNATURES.items():
+            for sig in sigs:
+                if header.startswith(sig):
+                    return fmt
+        return None
+
+    def detect_format(self, data: bytes, filename: str | None = None) -> Tuple[str, float]:
+        fmt = self.detect_by_magic_bytes(data)
+        if not fmt and filename:
+            lower = filename.lower()
+            if lower.endswith(".msg"):
+                fmt = "msg"
+            elif lower.endswith(".eml"):
+                fmt = "eml"
+        if not fmt:
+            fmt = "eml"  # default
+        confidence = 0.9 if fmt != "eml" else 0.5
+        return fmt, confidence

--- a/email_parser/parser.py
+++ b/email_parser/parser.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import email
+import email.parser
+import email.policy
+import logging
+import os
+import sys
+from email.message import Message
+from typing import Any, Dict, Optional, Union
+
+from .content_analyzer import ContentAnalyzer, FileAnalysis
+from .format_detector import EmailFormatDetector
+
+try:
+    import extract_msg
+    MSG_SUPPORT = True
+except Exception:  # pragma: no cover - optional
+    MSG_SUPPORT = False
+
+
+class EmailParser:
+    """High level API for parsing email messages."""
+
+    def __init__(self, log_level: int = logging.INFO) -> None:
+        self._setup_logging(log_level)
+        self.parser = email.parser.Parser(policy=email.policy.default)
+        self.bytes_parser = email.parser.BytesParser(policy=email.policy.default)
+        self.format_detector = EmailFormatDetector(self.logger)
+        self.content_analyzer = ContentAnalyzer(self.logger)
+
+    # ------------------------------------------------------------------
+    def _setup_logging(self, level: int) -> None:
+        logging.basicConfig(
+            level=level,
+            format="%(asctime)s - %(levelname)s - %(message)s",
+            handlers=[logging.StreamHandler(sys.stdout)],
+        )
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    def parse(self, input_data: Union[str, bytes], filename: str | None = None) -> Dict[str, Any]:
+        if isinstance(input_data, str):
+            data_bytes = input_data.encode()
+        else:
+            data_bytes = input_data
+
+        fmt, conf = self.format_detector.detect_format(data_bytes, filename)
+
+        message = self._parse_message(data_bytes, fmt)
+        if not message:
+            return {"status": "failed", "errors": ["could not parse message"], "detected_format": fmt}
+
+        structure = self._extract_structure(message)
+        return {
+            "status": "success",
+            "detected_format": fmt,
+            "format_confidence": conf,
+            "structure": structure,
+        }
+
+    # ------------------------------------------------------------------
+    def _parse_message(self, data: bytes, fmt: str) -> Optional[Message]:
+        if fmt == "msg":
+            if not MSG_SUPPORT:
+                self.logger.error("MSG support requires extract_msg")
+                return None
+            return self._parse_msg(data)
+        else:
+            try:
+                return self.bytes_parser.parsebytes(data)
+            except Exception as exc:  # pragma: no cover - parse errors
+                self.logger.error("Failed to parse EML: %s", exc)
+                return None
+
+    # ------------------------------------------------------------------
+    def _parse_msg(self, data: bytes) -> Optional[Message]:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".msg", delete=False) as tmp:
+            tmp.write(data)
+            tmp_path = tmp.name
+        try:
+            msg = extract_msg.Message(tmp_path)
+            content = self._convert_msg(msg)
+            return self.parser.parsestr(content)
+        finally:
+            os.unlink(tmp_path)
+
+    # ------------------------------------------------------------------
+    def _convert_msg(self, msg: Any) -> str:
+        lines = [
+            f"From: {getattr(msg, 'sender', '')}",
+            f"To: {getattr(msg, 'to', '')}",
+            f"Subject: {getattr(msg, 'subject', '')}",
+            "MIME-Version: 1.0",
+            "Content-Type: text/plain; charset=utf-8",
+            "",
+        ]
+        body = getattr(msg, "body", "")
+        if isinstance(body, bytes):
+            body = body.decode("utf-8", "replace")
+        lines.append(body)
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    def _extract_structure(self, message: Message) -> Dict[str, Any]:
+        attachments: list[Dict[str, Any]] = []
+        if message.is_multipart():
+            for part in message.walk():
+                if part.is_multipart():
+                    continue
+                if part.get_filename():
+                    data = part.get_payload(decode=True) or b""
+                    info = self.content_analyzer.analyze_content(data, part.get_filename(), part.get_content_type())
+                    attachments.append({
+                        "filename": part.get_filename(),
+                        "analysis": info.__dict__,
+                    })
+        body = self._get_body_text(message)
+        return {"attachment_count": len(attachments), "attachments": attachments, "body_preview": body[:80]}
+
+    # ------------------------------------------------------------------
+    def _get_body_text(self, msg: Message) -> str:
+        if msg.is_multipart():
+            for part in msg.walk():
+                if part.get_content_type() == "text/plain":
+                    payload = part.get_payload(decode=True)
+                    if payload:
+                        return payload.decode(part.get_content_charset() or "utf-8", "replace")
+        else:
+            payload = msg.get_payload(decode=True)
+            if payload:
+                return payload.decode(msg.get_content_charset() or "utf-8", "replace")
+        return ""

--- a/email_parser/tests/test_parser.py
+++ b/email_parser/tests/test_parser.py
@@ -1,0 +1,14 @@
+import logging
+
+import email_parser.parser as ep
+
+
+def test_magic_byte_detection():
+    detector = ep.EmailFormatDetector(logging.getLogger("test"))
+    assert detector.detect_by_magic_bytes(b"Return-Path:") == "eml"
+
+
+def test_parse_simple_eml(tmp_path):
+    sample = b"From: a@b\n\nbody"
+    result = ep.EmailParser().parse(sample, "sample.eml")
+    assert result["status"] == "success"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+
+[tool.pyupgrade]
+py38-plus = true


### PR DESCRIPTION
## Summary
- clean README
- add modular `email_parser` package with parser, format detection, and content analysis
- provide CLI entrypoint
- add diagnostic script and basic test suite
- configure formatting tools via `pyproject.toml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abcb045b88324af742ac1f8e84be6