### PR TITLE
Fix MSG parsing cleanup and handle None body

### DIFF
--- a/email_parser/tests/test_parser.py
+++ b/email_parser/tests/test_parser.py
@@ -12,3 +12,18 @@ def test_parse_simple_eml(tmp_path):
     sample = b"From: a@b\n\nbody"
     result = ep.EmailParser().parse(sample, "sample.eml")
     assert result["status"] == "success"
+
+
+class _DummyMsg:
+    def __init__(self, body=None):
+        self.sender = "s@a"
+        self.to = "t@b"
+        self.subject = "subj"
+        self.body = body
+
+
+def test_convert_msg_handles_none_body():
+    parser = ep.EmailParser()
+    content = parser._convert_msg(_DummyMsg(None))
+    assert "From: s@a" in content
+    assert isinstance(content, str)


### PR DESCRIPTION
## Summary
- close extract_msg handles before deleting tmp MSG file
- handle None body in _convert_msg
- test handling of None body in _convert_msg

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac0414fb88324a711fb2b7f2c559a