### PR TITLE
Fix missing imports

### DIFF
--- a/email_parser/__init__.py
+++ b/email_parser/__init__.py
@@ -5,6 +5,15 @@
 import logging
 import sys
 
+from .converters import HtmlToTextConverter
+from .content_analyzer import ContentAnalyzer
+from .normalizers import Utf16ContentNormalizer
+from .parser import EmailParser
+from .parsers.eml_parser import EmlFormatParser
+from .parsers.mbox_parser import MboxFormatParser
+from .parsers.msg_parser import MsgFormatParser
+from .structure_extractor import EmailStructureExtractor
+
 
 def create_email_parser(log_level: int = logging.INFO):
     """Factory function to create a fully configured EmailParser."""

--- a/email_parser/cli.py
+++ b/email_parser/cli.py
@@ -5,6 +5,9 @@
 import argparse
 import json
 from pathlib import Path
+import logging
+
+from . import create_email_parser
 
 
 def main() -> None:

--- a/email_parser/normalizers.py
+++ b/email_parser/normalizers.py
@@ -5,6 +5,8 @@
 import logging
 from typing import Union, Optional, Any
 
+from .interfaces import ContentNormalizer
+
 
 class BaseContentNormalizer(ContentNormalizer):
     """Base normalizer with common functionality."""

--- a/email_parser/parser.py
+++ b/email_parser/parser.py
@@ -5,6 +5,9 @@
 from typing import List, Dict, Any, Union, Optional
 import logging
 
+from .interfaces import EmailFormatParser
+from .structure_extractor import EmailStructureExtractor
+
 
 class EmailParser:
     """Main email parser that delegates to format-specific parsers."""

--- a/email_parser/parsers/eml_parser.py
+++ b/email_parser/parsers/eml_parser.py
@@ -4,6 +4,11 @@
 
 import email.parser
 import email.policy
+import logging
+from typing import Optional, Tuple
+from email.message import Message
+
+from ..interfaces import EmailFormatParser
 
 
 class EmlFormatParser(EmailFormatParser):

--- a/email_parser/parsers/mbox_parser.py
+++ b/email_parser/parsers/mbox_parser.py
@@ -2,6 +2,15 @@
 # email_parser/parsers/mbox_parser.py
 # ============================================================================
 
+import email.parser
+import email.policy
+import logging
+from typing import Optional, Tuple
+from email.message import Message
+
+from ..interfaces import EmailFormatParser
+
+
 class MboxFormatParser(EmailFormatParser):
     """Parser for MBOX email files."""
     

--- a/email_parser/parsers/msg_parser.py
+++ b/email_parser/parsers/msg_parser.py
@@ -6,10 +6,14 @@ import tempfile
 import os
 import base64
 import io
+import logging
 from typing import Optional, Tuple, List
 from email.message import Message
 import email.parser
 import email.policy
+
+from ..interfaces import EmailFormatParser, ContentNormalizer
+from ..converters import HtmlToTextConverter
 
 try:
     import extract_msg

--- a/email_parser/structure_extractor.py
+++ b/email_parser/structure_extractor.py
@@ -7,6 +7,9 @@ import base64
 import quopri
 from typing import Dict, Any, List, Optional
 from email.message import Message
+import logging
+
+from .converters import HtmlToTextConverter
 
 
 class EmailStructureExtractor:


### PR DESCRIPTION
## Summary
- add needed imports in `__init__`, `cli`, `parser`, and helpers
- add imports for parser modules
- include logging and converter imports for structure extractor

## Testing
- `python -m compileall -q email_parser diagnostics standalone`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_686ac97ef20c8324a8db4c443eb4907c