### PR TITLE
Clean up unused code and tidy CLI

### DIFF
--- a/email_parser/cli.py
+++ b/email_parser/cli.py
@@ -9,8 +9,7 @@ import logging
 
 from . import create_email_parser
 
-def main() -> None:
-    """Command line interface for the email parser."""
+
 def main() -> None:
     """Command line interface for the email parser."""
     parser = argparse.ArgumentParser(description="Email parsing utility with URL analysis")

--- a/email_parser/structure_extractor.py
+++ b/email_parser/structure_extractor.py
@@ -63,8 +63,7 @@ class EmailStructureExtractor:
             'body': self._extract_streamlined_body(message),
             'attachments': [],
             'nested_emails': [],
-            'urls': [],
-            'suspicious_indicators': []
+            'urls': []
         }
         
         # Process attachments and nested emails
@@ -534,9 +533,9 @@ class EmailStructureExtractor:
         
         # Collect domains
         domains = set()
-        for email in all_emails:
+        for email_entry in all_emails:
             for header in ['from', 'to', 'cc']:
-                value = email.get('headers', {}).get(header, '')
+                value = email_entry.get('headers', {}).get(header, '')
                 if '@' in value:
                     try:
                         # Extract domain from email address - handle different formats
@@ -551,14 +550,14 @@ class EmailStructureExtractor:
                             domain = email_part.split('@')[1].strip()
                             if domain:
                                 domains.add(domain)
-                    except:
+                    except Exception:
                         pass
         
         # Collect attachment types from all emails
         attachment_types = set()
         total_attachments = 0
-        for email in all_emails:
-            for att in email.get('attachments', []):
+        for email_entry in all_emails:
+            for att in email_entry.get('attachments', []):
                 attachment_types.add(att.get('type', 'unknown'))
                 total_attachments += 1
         


### PR DESCRIPTION
## Summary
- remove unused `suspicious_indicators` field
- rename loop variables and catch specific exception
- fix duplicate `main` function in CLI

## Testing
- `python -m compileall -q email_parser`
- `/root/.pyenv/versions/3.12.10/bin/ruff check email_parser | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686af4e4f17483248e7ec263991c7dcc