### PR TITLE
Enable document processing by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ This project provides a small library for parsing `.eml` and `.msg` files with a
 ```bash
 python -m email_parser.cli path/to/email.eml
 ```
+
+Document text extraction and URL parsing from attachments are enabled by default.
+Use `--no-document-processing` if you wish to disable this behavior.


### PR DESCRIPTION
## Summary
- add `enable_document_processing` option to `EmailStructureExtractor`
- skip document extraction steps when disabled
- mention default document processing in README

## Testing
- `ruff check .`
- `pytest -q`
- `python - <<'EOF'
import email_parser
parser = email_parser.create_email_parser()
res = parser.parse("From: a@example.com\nTo: b@example.com\nSubject: Hi\n\nBody", filename="sample.eml")
print(res['status'], 'urls' in res['structure'])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686afc797a6483249c5ab524aca99dbd