### PR TITLE
Fix ASCII arrow in forwarding chain

### DIFF
--- a/email_parser/structure_extractor.py
+++ b/email_parser/structure_extractor.py
@@ -795,7 +795,7 @@ class EmailStructureExtractor:
             from_addr = email.get("headers", {}).get("from", "")
             to_addr = email.get("headers", {}).get("to", "")
             if from_addr and to_addr:
-                forwarding_chain.append(f"{from_addr} → {to_addr}")
+                forwarding_chain.append(f"{from_addr} -> {to_addr}")
 
             # Process nested emails recursively
             for nested in email.get("nested_emails", []):


### PR DESCRIPTION
## Summary
- use ASCII arrow in forwarding chain

## Testing
- `python -m email_parser.cli --help`

------
https://chatgpt.com/codex/tasks/task_e_686b1a54a424832481867f39edb14277