### PR TITLE
Fix duplicate nested email extraction for MSG files

### DIFF
--- a/function-app/email_parser/structure_extractor.py
+++ b/function-app/email_parser/structure_extractor.py
@@ -1212,9 +1212,13 @@ class EmailStructureExtractor:
 
                 # Check for nested email in attachment
                 if attachment.get("contains_email"):
-                    nested_email = self._extract_nested_email_streamlined(
-                        part, depth + 1
-                    )
+                    # Use already extracted nested email if available to avoid duplication
+                    nested_email = attachment.get("nested_email")
+                    if not nested_email:
+                        # Fallback: extract if not already done
+                        nested_email = self._extract_nested_email_streamlined(
+                            part, depth + 1
+                        )
                     if nested_email:
                         nested_email["source_attachment"] = (
                             filename or f"attachment_{len(attachments)}"


### PR DESCRIPTION
- Prevent duplicate extraction of nested emails in MSG attachments
- Use already extracted nested_email from attachment object instead of re-extracting
- Maintains fallback logic for cases where nested email wasn't already extracted
- Fixes issue where nested MSG files were detected but not properly added to email structure layers

